### PR TITLE
Add desynchronization monitoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Open config-sample.json in your favourite text editor and edit with your own set
     "retries_threshold": 3,
     "feeds_to_check" : ["<mpa_asset>"],
     "feed_publication_threshold": 60,
-    "feed_checking_interval": 10
+    "feed_checking_interval": 10,
+    "stale_blockchain_threshold": 10
 }
 ``` 
   
@@ -55,6 +56,7 @@ and then save as config.json
 | `feeds_to_check`| Array of assets symbols where the price publication should be checked. |
 | `feed_publication_threshold` | How many minutes before a feed is considered as missing. |
 | `feed_checking_interval` | How often should the script check for unpublished feeds. | 
+| `stale_blockchain_threshold` | How many seconds before a node is considered desynchronized (should be more than block time).| 
 
 ## Running
 

--- a/config-sample.json
+++ b/config-sample.json
@@ -13,5 +13,6 @@
     "retries_threshold": 3,
     "feeds_to_check" : [],
     "feed_publication_threshold": 60,
-    "feed_checking_interval": 10
+    "feed_checking_interval": 10,
+    "stale_blockchain_threshold": 10
 }

--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ function send_settings(recipient_id) {
         `Witness monitored: \`${config.witness_id}\``,
         `Checking interval: \`${config.checking_interval} sec\``,
         `Node failed connection attempt notification threshold: \`${config.retries_threshold}\``,
+        `Desynchronization threshold: \`${config.stale_blockchain_threshold}\` sec`,
         `Missed block threshold: \`${config.missed_block_threshold}\``,
         `Missed block reset time window: \`${config.reset_period} sec\``,
         `Public signing keys: ${config.witness_signing_keys.map(k => '`' + k + '`').join(', ')}`,

--- a/lib/ValidateConfig.js
+++ b/lib/ValidateConfig.js
@@ -100,6 +100,13 @@ var constraints = {
             onlyInteger: true,
             greaterThan: 0
         }
+    },
+    "stale_blockchain_threshold": {
+        presence: true,
+        numericality: {
+            onlyInteger: true,
+            greaterThan: 0
+        }
     }
 }
 

--- a/lib/WitnessMonitor.js
+++ b/lib/WitnessMonitor.js
@@ -192,6 +192,21 @@ class WitnessMonitor extends EventEmitter {
             });
     }
 
+    check_node_synchronization() {
+        return Apis.instance().db_api().exec('get_dynamic_global_properties', [])
+            .then((global_properties) => {
+                const block_age_in_seconds = moment.utc().diff(moment.utc(global_properties.time), 'seconds')
+                if (block_age_in_seconds > this._config.stale_blockchain_threshold) {
+                    this.notify(`Node not synchronized, last block recieved ${block_age_in_seconds} seconds ago (at ${global_properties.time}).`)
+                }
+                return Promise.resolve();
+            })
+            .catch(error => {
+                this._logger.log(`Unable to retrieve dynamic global properties: ${error}`);
+                throw error;
+            });
+    }
+
     start_monitoring() {
         this._logger.log('Starting witness health monitor');
         this.emit('started');
@@ -217,7 +232,8 @@ class WitnessMonitor extends EventEmitter {
                         this.reset_missed_block_window()
                     }
         
-                    return Promise.all([this.check_activeness(), this.check_missed_blocks(), this.check_publication_feeds()]);
+                    return Promise.all([this.check_node_synchronization(), this.check_activeness(), 
+                                        this.check_missed_blocks(), this.check_publication_feeds()]);
                 });
             
             }).catch((error) => {

--- a/test/test_config_validation.js
+++ b/test/test_config_validation.js
@@ -19,7 +19,8 @@ const valid_config = {
     "retries_threshold": 3,
     "feeds_to_check" : ["HERTZ", "USD"],
     "feed_publication_threshold": 60,
-    "feed_checking_interval": 10
+    "feed_checking_interval": 10,
+    "stale_blockchain_threshold": 10
 }
 
 


### PR DESCRIPTION
Following testnet issue of 07/08/2018 an alert is raised when the api node does not return a recent block time.

New configuration parameter: 

- `stale_blockchain_threshold`: How many seconds before a node is considered desynchronized (should be more than block time).