### PR TITLE
Allow to set a different threshold for each feed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Open config-sample.json in your favourite text editor and edit with your own set
     "telegram_token": "<telegram_access_token>",
     "telegram_authorized_users": ["<user_id>"],
     "retries_threshold": 3,
-    "feeds_to_check" : ["<mpa_asset>"],
-    "feed_publication_threshold": 60,
+    "feeds_to_check" : {
+        "USD": 60,
+        "CNY": 120,
+    },
     "feed_checking_interval": 10,
     "stale_blockchain_threshold": 10
 }
@@ -53,8 +55,7 @@ and then save as config.json
 | `telegram_token`  | The telegram access token for your notifications bot. You can create one with [BotFather](https://telegram.me/BotFather). |
 | `telegram_authorized_users` | List of userId authorized to interact with the bot. You can get your user Id by talking to the bot, or use a bot like [@userinfobot](https://telegram.me/userinfobot). |
 | `retries_threshold`  | Number of failed connections to API node before the bot notifies you on telegram. |
-| `feeds_to_check`| Array of assets symbols where the price publication should be checked. |
-| `feed_publication_threshold` | How many minutes before a feed is considered as missing. |
+| `feeds_to_check`| Dictionary of assets symbols (and their respective tolerated max age in minutes) which price publication should be checked. |
 | `feed_checking_interval` | How often should the script check for unpublished feeds. | 
 | `stale_blockchain_threshold` | How many seconds before a node is considered desynchronized (should be more than block time).| 
 
@@ -112,9 +113,8 @@ Open a chat to your bot and use the following:
 - `/window Z` : Set the time until missed blocks counter is reset to Z seconds.
 - `/recap T` : Set the auto-notification interval of latest stats to every T minutes. Set to 0 to disable.
 - `/retries N` : Set the threshold for failed API node connection attempts to N times before notifying you in telegram.
-- `/feed_publication_threshold X`: Set the feed threshold to X minutes.
 - `/feed_checking_interval I`: Set the interval of publication feed check to I minutes.
-- `/feeds <symbol1> <symbol2> <symbol3> ...`: Set the feeds to check to the provided list.
+- `/feeds <symbol1>:<threshold1> <symbol2>:<threshold2> ...`: Set the feeds (and their threshold) to check to the provided list.
 - `/reset` : Reset the missed blocks counter in the current time-window.
 - `/pause` : Pause monitoring.
 - `/resume`: Resume monitoring.
@@ -134,7 +134,6 @@ interval - Set the checking interval
 window - Set the time until missed blocks counter is reset
 recap - Set the auto-notification interval of latest stats
 retries - Set the threshold for failed API node connection attempts 
-feed_publication_threshold - Set the feed threshold
 feed_checking_interval - Set the interval of publication feed check
 feeds - Set the feeds to check
 reset - Reset the missed blocks counter

--- a/config-sample.json
+++ b/config-sample.json
@@ -11,8 +11,7 @@
     "telegram_token": "",
     "telegram_authorized_users": [],
     "retries_threshold": 3,
-    "feeds_to_check" : [],
-    "feed_publication_threshold": 60,
+    "feeds_to_check" : {},
     "feed_checking_interval": 10,
     "stale_blockchain_threshold": 10
 }

--- a/lib/ValidateConfig.js
+++ b/lib/ValidateConfig.js
@@ -14,6 +14,16 @@ validate.validators.signing_keys = function(value, options, key, attributes) {
         }
     }
 }
+validate.validators.feed_configuration = function(value, options, key, attributes) {
+    if (!validate.isObject(value) || validate.isArray(value)) {
+        return 'should be an map of asset_name -> threshold';
+    }
+
+    const errors = Object.keys(value).filter(k => !validate.isInteger(value[k]) || value[k] <= 0)
+    if (errors.length > 0) {
+        return `thresholds for ${errors.join(', ')} should be integer`
+    } 
+}
 
 var constraints = {
     "witness_id": {
@@ -86,13 +96,8 @@ var constraints = {
             greaterThan: 0
         }
     },
-    "feeds_to_check" : {},
-    "feed_publication_threshold": {
-        presence: true,
-        numericality: {
-            onlyInteger: true,
-            greaterThan: 0
-        }
+    "feeds_to_check" : {
+        feed_configuration: true    
     },
     "feed_checking_interval": {
         presence: true,

--- a/lib/WitnessMonitor.js
+++ b/lib/WitnessMonitor.js
@@ -115,34 +115,35 @@ class WitnessMonitor extends EventEmitter {
                 }
             }
             
-            feeds_stats.set(symbol, new FeedStat(symbol,my_publication_time, my_price, average_price));
+            feeds_stats.set(symbol, new FeedStat(symbol, my_publication_time, my_price, average_price));
         });
         return feeds_stats;
     }
 
     check_publication_feeds() {
-        const has_no_feed_check_configured = !('feeds_to_check' in this._config) || this._config.feeds_to_check.length == 0;
+        const has_no_feed_check_configured = !('feeds_to_check' in this._config) || Object.keys(this._config.feeds_to_check).length == 0;
         const is_not_time_to_check_feeds = this._last_feed_check != null && moment().diff(this._last_feed_check, 'minutes') < this._config.feed_checking_interval
         if (has_no_feed_check_configured || is_not_time_to_check_feeds) {
             return Promise.resolve();
         } 
     
-        return Apis.instance().db_api().exec('lookup_asset_symbols', [this._config.feeds_to_check])
+        return Apis.instance().db_api().exec('lookup_asset_symbols', [Object.keys(this._config.feeds_to_check)])
             .then((assets) => {
                 const dynamic_asset_data_ids = assets.map(a => a['bitasset_data_id']);
                 return Apis.instance().db_api().exec('get_objects', [dynamic_asset_data_ids]);
             })
             .then(dynamic_assets_data => {
                 this._last_feed_check = moment();
-                this._feed_stats = this.extract_feed_data(this._config.feeds_to_check, dynamic_assets_data, this._witness_account);
+                this._feed_stats = this.extract_feed_data(Object.keys(this._config.feeds_to_check), dynamic_assets_data, this._witness_account);
                 this._feed_stats.forEach(feed_stat => {
                     this._logger.log(feed_stat.toString());
                     if (feed_stat.publication_time == null) {
                         this.notify(`No publication found for ${feed_stat.name}.`);
                     } else {
-                        if (feed_stat.since().as('minutes') > this._config.feed_publication_threshold) {
+                        const threshold = this._config.feeds_to_check[feed_stat.name]
+                        if (feed_stat.since().as('minutes') > threshold) {
                             const price_feed_alert = [
-                                `More than ${this._config.feed_publication_threshold} minutes elapsed since last publication of ${feed_stat.name}.`,
+                                `More than ${threshold} minutes elapsed since last publication of ${feed_stat.name}.`,
                                 feed_stat.toString()
                             ];
                             this.notify(price_feed_alert.join('\n'));

--- a/test/test_config_validation.js
+++ b/test/test_config_validation.js
@@ -17,8 +17,10 @@ const valid_config = {
     "telegram_token": "XXXXXXX:YYYYYYYYYY",
     "telegram_authorized_users": ["1234"],
     "retries_threshold": 3,
-    "feeds_to_check" : ["HERTZ", "USD"],
-    "feed_publication_threshold": 60,
+    "feeds_to_check" : {
+        "HERTZ": 60, 
+        "USD": 30
+    },
     "feed_checking_interval": 10,
     "stale_blockchain_threshold": 10
 }
@@ -80,6 +82,25 @@ describe('#validate_config()', function() {
         var config = Object.assign({}, valid_config);
         config.witness_signing_keys = [ 'BTSXXXXXXXXXX', 'BTCXXXXXXXX'];
         assert('witness_signing_keys' in validate_config(config));
+    });
+
+    it('should detect feed check configured as non object', function() {
+        var config = Object.assign({}, valid_config);
+        config.feeds_to_check = 'AMAZONCOM';
+        assert('feeds_to_check' in validate_config(config));
+    });
+
+
+    it('should detect feed check configured as array', function() {
+        var config = Object.assign({}, valid_config);
+        config.feeds_to_check = [ 'AMAZONCOM', 'USD' ];
+        assert('feeds_to_check' in validate_config(config));
+    });
+
+    it('should detect feed check configured with invalid threshold', function() {
+        var config = Object.assign({}, valid_config);
+        config.feeds_to_check = { 'AMAZONCOM': 'blabla', 'USD': 40 };
+        assert('feeds_to_check' in validate_config(config));
     });
 
 });


### PR DESCRIPTION
Previously it was possible to set only one threshold to check publication feeds.

But some assets are more volatile than others, so it's not easy to have a unique threshold to detect too old feeds.

This Pull Request add the ability to configure a threshold for each asset.

Be carefull the configuration format has changed from:

```
    "feeds_to_check" : [ "USD", "CNY"],
    "feed_publication_threshold": 60,
```

to:

```
    "feeds_to_check" : {
        "USD": 60, 
        "CNY": 40
    }
```
